### PR TITLE
rename var definition

### DIFF
--- a/config.js
+++ b/config.js
@@ -14,7 +14,7 @@ var config = {
 	auth_url: 'https://auth.mercadolibre.com/authorization',
 	oauth_url: 'https://api.mercadolibre.com/oauth/token',
 	client_id :  process.env.App_ID,
-	secret_key : process.env.Secret_Key,
+	client_secret : process.env.Secret_Key,
 	redirect_uri : process.env.Redirect_URI,
 	site_id : 'MLA'
 };


### PR DESCRIPTION
This variable is used at master/lib/meli.js under line 31 as client_secret: config.client_secret, so I guess we should update current var definition on config file. Otherwise this would never be read at meli.js file.